### PR TITLE
Create mocks from erlang modules

### DIFF
--- a/lib/elixir_mock.ex
+++ b/lib/elixir_mock.ex
@@ -421,7 +421,7 @@ defmodule ElixirMock do
     invalid_stubs =
       mock_fns
       |> Enum.filter(fn {fn_type, _} -> fn_type == :def end)
-      |> Enum.filter(fn {:def, stub} -> not stub in real_functions end)
+      |> Enum.filter(fn {:def, stub} -> not(stub in real_functions) end)
       |> Enum.map(fn {:def, stub} -> stub end)
 
     if not Enum.empty?(invalid_stubs) do
@@ -441,7 +441,7 @@ defmodule ElixirMock do
 
       ElixirMock.inject_monitored_real_functions(unquote(real_module),
                                                  unquote(real_module).module_info(:exports)
-                                                 |> Enum.filter(fn {fn_name, arity} -> not {fn_name, arity} in unquote(stubs) end)
+                                                 |> Enum.filter(fn {fn_name, arity} -> not({fn_name, arity} in unquote(stubs)) end)
                                                  |> Enum.map(fn {fn_name, arity} -> {fn_name, arity, unquote(call_through_unstubbed_fns)} end))
 
       ElixirMock.inject_elixir_mock_utilities(unquote(context))

--- a/lib/mock_watcher.ex
+++ b/lib/mock_watcher.ex
@@ -8,6 +8,10 @@ defmodule MockWatcher do
     GenServer.start_link(__MODULE__, %{calls: []}, name: watcher_name)
   end
 
+  def init(init_arg) do
+    {:ok, init_arg}
+  end
+
   def handle_call({:record_call, fn_name, args}, _from, state) do
     calls = state.calls ++ [{fn_name, args}]
     {:reply, :ok, %{state | calls: calls}}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirMock.Mixfile do
   def project do
     [
       app: :elixir_mock,
-      version: "0.2.8",
+      version: "0.2.9",
       elixir: "~> 1.4",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/test/elixir_mock_tests/mock_definition_test.exs
+++ b/test/elixir_mock_tests/mock_definition_test.exs
@@ -22,6 +22,18 @@ defmodule ElixirMockTest.Definition do
     assert RealModule.function_one(1) == :real_result_one
   end
 
+  test "should create simple mocks from erlang modules" do
+    mock = mock_of :erlang
+    assert mock.self() == nil
+  end
+
+  test "should create custom mocks from erlang modules" do
+    with_mock(mock) = defmock_of :inet do
+      def ip(_), do: :fake_ip
+    end
+    assert mock.ip(nil) == :fake_ip
+  end
+
   test "should allow functions on mock to delegate to real module functions when they return :call_through" do
     with_mock(mock) = defmock_of RealModule do
       def function_one(_), do: :call_through


### PR DESCRIPTION
Allows for creation of mocks from modules like `:erlang` and `:inet`